### PR TITLE
Back to dev version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   </properties>
 
   <artifactId>mathworks-polyspace</artifactId>
-  <version>1.0.9</version>
+  <version>1.0.10-SNAPSHOT</version>
   <groupId>io.jenkins.plugins</groupId>
   <name>MathWorks Polyspace Plugin</name>
   <url>https://github.com/jenkinsci/mathworks-polyspace-plugin</url>
@@ -39,7 +39,7 @@
     <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin.git</url>
-    <tag>mathworks-polyspace-1.0.9</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
ed1f4873fa1b1da4ea3f73b1356ded474d648fb8 was not paired with the expected “back to development version” commit, indicating a botched release.

If you do not want to publish releases manually and deal with local authentication issues and so on, you can also consider [automated releases](https://www.jenkins.io/doc/developer/publishing/releasing-cd/).