### PR TITLE
Generate incremental builds from ci.jenkins.io

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,7 +1,7 @@
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
-    <extension>
-        <groupId>io.jenkins.tools.incrementals</groupId>
-        <artifactId>git-changelist-maven-extension</artifactId>
-        <version>1.7</version>
-    </extension>
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.8</version>
+  </extension>
 </extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,4 +1,2 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
--Pconsume-incrementals
--Pmight-produce-incrementals

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,4 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,15 @@
   </parent>
 
   <properties>
+    <revision>1.0.10</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/mathworks-polyspace-plugin</gitHubRepo>
     <jenkins.version>2.426.3</jenkins.version>
     <findbugs.failOnError>true</findbugs.failOnError>
   </properties>
 
   <artifactId>mathworks-polyspace</artifactId>
-  <version>1.0.10-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <groupId>io.jenkins.plugins</groupId>
   <name>MathWorks Polyspace Plugin</name>
   <url>https://github.com/jenkinsci/mathworks-polyspace-plugin</url>
@@ -36,9 +39,9 @@
   </developers>
 
   <scm>
-    <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin.git</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}.git</url>
     <tag>${scmTag}</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.78</version>
+    <version>4.83</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,21 +59,6 @@
     </pluginRepository>
   </pluginRepositories>
 
-  <build>
-    <plugins>
-      <!-- require org.apache.maven.plugins:maven-clean-plugin -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>InjectedTest.java</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <properties>
-    <revision>1.0.10</revision>
+    <revision>1.0.11</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/mathworks-polyspace-plugin</gitHubRepo>
     <jenkins.version>2.426.3</jenkins.version>


### PR DESCRIPTION
## Generate incremental builds from ci.jenkins.io

- 03820ef843a0709015435ef05bec5bd0b838a634 Finish incrementalify process
- 5094fd2c882bdec7a90d471a09292a7cc6061685 Do not exclude InjectedTest
- b4d67659a5985fce52789cdb1ee7dccb2dd71e26 Use parent pom 4.83 - most recent
- c6335995726f2f26b3fe5c304b49244ecf3f3dbf Set next version as 1.0.11 since 1.0.10 has already been tagged

It appears that [incremental creation](https://www.jenkins.io/doc/developer/plugin-development/incrementals/) was [started](https://github.com/jenkinsci/mathworks-polyspace-plugin/pull/3/files#diff-e2fd31b1ba58a94be3424fe9df7410c47c27187dd00fc501f28e1d3a3443870c) but not completed.  An incremental build is a nice help for testing pre-release versions of the plugin with configuration as code.  I use that technique to test plugin versions in my [plugins.txt file](https://github.com/MarkEWaite/docker-lfs/blob/b957079b19532ad36861f2bf1443ddeaec21ed7c/plugins.txt#L102).

The result is visible in the [first GitHub checks page](https://github.com/jenkinsci/mathworks-polyspace-plugin/pull/5/checks?check_run_id=26398170650) and in the [most recent GitHub checks page](https://github.com/jenkinsci/mathworks-polyspace-plugin/pull/5/checks?check_run_id=26416695573) where it recommends the settings a user needs for the incremental build of this pull request.

### Testing done

Confirmed that automated tests pass on my Linux computer with JDK 21.0.3 and Apache Maven 3.9.8.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
