### PR TITLE
Remove unnecessary fixed version on JUnit and Mockito from pom.xml and bump org.jenkins-ci.plugins to 5.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.17</version>
+    <version>5.18</version>
     <relativePath />
   </parent>
 
@@ -69,36 +69,6 @@
         <version>4969.v6ffa_18d90c9f</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-api</artifactId>
-          <version>5.12.2</version>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-engine</artifactId>
-          <version>5.12.2</version>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.junit.platform</groupId>
-          <artifactId>junit-platform-launcher</artifactId>
-          <version>1.12.2</version>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-core</artifactId>
-          <version>5.18.0</version>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-junit-jupiter</artifactId>
-          <version>5.18.0</version>
-          <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Remove unnecessary fixed version on JUnit and Mockito from pom.xml and bump org.jenkins-ci.plugins to 5.18
